### PR TITLE
ログ解析周りの改善

### DIFF
--- a/src/app/(app)/analyze-logs/_components/LogAnalysisCharts.tsx
+++ b/src/app/(app)/analyze-logs/_components/LogAnalysisCharts.tsx
@@ -39,6 +39,8 @@ export const LogAnalysisCharts: FC = () => {
   const { character } = useCharacterSelect();
   const result = useCharacterLogAnalysis(character);
 
+  console.log(result);
+
   useEffect(() => {
     import('chart.js').then(
       ({ Chart, BarController, CategoryScale, LinearScale, BarElement }) => {
@@ -63,9 +65,22 @@ export const LogAnalysisCharts: FC = () => {
   const diceResultNumber = withNumberDiceResults.map(
     ({ diceResultNumber }) => diceResultNumber,
   );
-  const aggregatedDiceResultNumber = Object.values(
-    groupBy(diceResultNumber, (result) => Math.floor((result - 1) / 10)),
-  ).map((results) => (results ? results.length : 0));
+  const defaultDiceResultNumber: Record<number, number[]> = {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [],
+    6: [],
+    7: [],
+    8: [],
+    9: [],
+  };
+  const aggregatedDiceResultNumber = Object.values({
+    ...defaultDiceResultNumber,
+    ...groupBy(diceResultNumber, (result) => Math.floor((result - 1) / 10)),
+  }).map((results) => (results ? results.length : 0));
   const diceResultNumberLabels = [...Array(10)].map(
     (_, i) => `${i * 10 + 1}-${i * 10 + 10}`,
   );

--- a/src/app/(app)/analyze-logs/_components/hooks/ccfoliaLogAnalysis/index.ts
+++ b/src/app/(app)/analyze-logs/_components/hooks/ccfoliaLogAnalysis/index.ts
@@ -30,10 +30,12 @@ export const analyzeCcfoliaLog = (html: string) => {
 
   const extractedLogs = logElements.map(extractLogFromElement);
   const parsedLogs = extractedLogs
-    .map(({ message, ...log }) => ({
-      ...log,
-      result: parseMessage(message),
-    }))
+    .flatMap(({ message, ...log }) =>
+      parseMessage(message).map((result) => ({
+        ...log,
+        result,
+      })),
+    )
     .filter(({ result }) => result !== undefined) as ParsedLog[];
 
   const analyzedLogs = parsedLogs.map((log) => ({

--- a/src/app/(app)/analyze-logs/_components/hooks/ccfoliaLogAnalysis/messageParser.ts
+++ b/src/app/(app)/analyze-logs/_components/hooks/ccfoliaLogAnalysis/messageParser.ts
@@ -12,8 +12,8 @@ const Coc7thMatcher: Matcher = (message) => {
   const match = message.match(CoC7thDiceRollRegex);
   if (match === null) return;
 
-  const diceTarget = parseInt(match[2], 10);
-  const diceResultNumber = match[2].includes(',')
+  const diceTarget = parseInt(match[1], 10);
+  const diceResultNumber = match[3].includes(',')
     ? undefined
     : parseInt(match[4], 10);
   const diceResult = match[5];

--- a/src/app/(app)/analyze-logs/_components/hooks/ccfoliaLogAnalysis/messageParser.ts
+++ b/src/app/(app)/analyze-logs/_components/hooks/ccfoliaLogAnalysis/messageParser.ts
@@ -33,13 +33,39 @@ const CoC6thMatcher: Matcher = (message) => {
 
 const matchers: Matcher[] = [Coc7thMatcher, CoC6thMatcher];
 
-export type MessageParser = (
+export type SingleMessageParser = (
   message: string,
-) => (MatcherResult & { message: string }) | undefined;
+) => MatcherResult | undefined;
 
-export const parseMessage: MessageParser = (message) => {
+const parseSingleMessage: SingleMessageParser = (message: string) => {
   for (const matcher of matchers) {
     const result = matcher(message);
-    if (result) return { message, ...result };
+    if (result !== undefined) return { message, ...result };
   }
+};
+
+const repeatDiceRollPrefixRegex = /^x(\d+)\s/;
+const convertRepeatDiceRollMessage = (message: string) => {
+  const match = message.match(repeatDiceRollPrefixRegex);
+  if (match === null) return [message];
+
+  const repeatCount = parseInt(match[1], 10);
+  const normalizedMessage = message.replace(/(x\d+.*)\s#1\n/, '$1\n\n#1\n');
+
+  const diceRollStr = normalizedMessage
+    .split('\n')[0]
+    .replace(repeatDiceRollPrefixRegex, '');
+
+  return normalizedMessage
+    .replace(/\n#(\d+)\n/g, `($1/${repeatCount}) ${diceRollStr} `)
+    .split('\n')
+    .slice(1);
+};
+
+export type MessageParser = (
+  message: string,
+) => ReturnType<SingleMessageParser>[];
+
+export const parseMessage: MessageParser = (message) => {
+  return convertRepeatDiceRollMessage(message).map(parseSingleMessage);
 };


### PR DESCRIPTION
fix #48

- ログが少なく、0になるような範囲がある場合のグラフの表示を修正
- 繰り返しダイスの全体を正しく処理できるように
