### PR TITLE
fix: stabilize hook tests and chart rendering

### DIFF
--- a/src/app/[locale]/(app)/analyze-logs/_components/LogAnalysisRankingChart.tsx
+++ b/src/app/[locale]/(app)/analyze-logs/_components/LogAnalysisRankingChart.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import type { FC } from 'react';
 
 import { useCharacterLogAnalysis } from './hooks/useCharacterLogAnalysis';
 import { useCharacterSelect } from './hooks/useCharacterSelect';
-const LogAnalysisRankingChartView = dynamic(
-  () => import('./LogAnalysisRankingChartView').then((mod) => mod.LogAnalysisRankingChartView),
-  { ssr: false, loading: () => <div className="h-75" /> },
-);
+import { LogAnalysisRankingChartView } from './LogAnalysisRankingChartView';
 
 interface LogAnalysisRankingChartProps {
   className?: string;

--- a/src/app/[locale]/(app)/analyze-logs/_components/LogAnalysisRankingChart.tsx
+++ b/src/app/[locale]/(app)/analyze-logs/_components/LogAnalysisRankingChart.tsx
@@ -18,7 +18,7 @@ export const LogAnalysisRankingChart: FC<LogAnalysisRankingChartProps> = ({ clas
   const { character } = useCharacterSelect();
   const result = useCharacterLogAnalysis(character);
 
-  if (!result) return <div className="h-75" />;
+  const score = result ? result.summary.deviationScore : 0;
 
-  return <LogAnalysisRankingChartView score={result.summary.deviationScore} className={className} />;
+  return <LogAnalysisRankingChartView score={score} className={className} />;
 };

--- a/src/app/[locale]/(app)/dice/_components/hooks/useGameSystemList.test.ts
+++ b/src/app/[locale]/(app)/dice/_components/hooks/useGameSystemList.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test, vi } from 'bun:test';
 
 import { act, renderHook } from '@testing-library/react';
-import { useAtom } from 'jotai';
 import * as useImmutableSWR from 'swr/immutable';
-
-import * as useLocalStorage from '@/shared/lib/useLocalStorage';
 
 import { useGameSystemList } from './useGameSystemList';
 
@@ -25,11 +22,6 @@ describe('useGameSystemList', () => {
       mutate: vi.fn(),
       error: undefined,
       isValidating: false,
-    });
-
-    const spy2 = vi.spyOn(useLocalStorage, 'useLocalStorageAtom');
-    spy2.mockImplementation((_key, atom, _schema) => {
-      return useAtom(atom);
     });
   });
 

--- a/src/app/[locale]/(app)/dice/_components/hooks/useGameSystemList.test.ts
+++ b/src/app/[locale]/(app)/dice/_components/hooks/useGameSystemList.test.ts
@@ -34,7 +34,7 @@ describe('useGameSystemList', () => {
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('ゲームシステムの一覧を取得してくる', () => {

--- a/src/app/[locale]/(app)/expect/_components/ExpectResultDistributionChartView.tsx
+++ b/src/app/[locale]/(app)/expect/_components/ExpectResultDistributionChartView.tsx
@@ -49,19 +49,21 @@ export const ExpectResultDistributionChartView: FC<{ result: DiceExpecterResult 
   const labels = Object.keys(result.distribution).sort((a, b) => Number(a) - Number(b));
 
   return (
-    <Line
-      data={{
-        labels,
-        datasets: [
-          {
-            data: labels.map((key) => result.distribution[key]),
-            fill: true,
-            segment: { backgroundColor: color, borderColor: color },
-          },
-        ],
-      }}
-      height={300}
-      options={options}
-    />
+    <div className="relative h-75">
+      <Line
+        data={{
+          labels,
+          datasets: [
+            {
+              data: labels.map((key) => result.distribution[key]),
+              fill: true,
+              segment: { backgroundColor: color, borderColor: color },
+            },
+          ],
+        }}
+        height={300}
+        options={options}
+      />
+    </div>
   );
 };

--- a/src/test/happy-dom.ts
+++ b/src/test/happy-dom.ts
@@ -1,3 +1,8 @@
+import { afterEach } from 'bun:test';
+
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
 GlobalRegistrator.register();
+
+const { cleanup } = await import('@testing-library/react');
+afterEach(cleanup);


### PR DESCRIPTION
## Summary

- register Testing Library cleanup for Bun tests
- stop mocking `useLocalStorageAtom` in `useGameSystemList` tests
- restore remaining spies after each test
- constrain the expectation chart height and keep the ranking chart mounted before data arrives
- simplify ranking-chart loading by removing the unnecessary dynamic import

## Root cause

Bun did not provide the global lifecycle hook that Testing Library uses for automatic cleanup. A mounted `useDiceRollCore` hook therefore survived into the next test; after its API spy was restored, a shared Jotai update re-rendered it with a different hook topology and React rejected the render.

## Validation

- hook tests passed across 40 randomized execution orders
- `bun run typecheck`
- `bun test` (137 passed)
- GitHub Actions: all checks passed