### PR TITLE
fix: Firebase Emulator を bunx 経由で起動

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         background: true
       - uses: ./.github/actions/setup
       - wait: java
+      - run: bunx --package firebase-tools@15.23.0 firebase --version
       - run: bun test
 
   build:

--- a/firebase/firestore.rules.test.ts
+++ b/firebase/firestore.rules.test.ts
@@ -190,10 +190,12 @@ describe('Firestore セキュリティルール', () => {
       if (!firestoreRunning) emulators.push('firestore');
       if (!storageRunning) emulators.push('storage');
 
-      const firebaseCli = resolve(process.cwd(), 'node_modules/.bin/firebase');
       emulatorProcess = spawn(
-        firebaseCli,
+        'bunx',
         [
+          '--package',
+          'firebase-tools@15.23.0',
+          'firebase',
           'emulators:start',
           '--only',
           emulators.join(','),


### PR DESCRIPTION
## 変更内容

- Firestore セキュリティルールテストの Emulator 起動を、削除済みの `node_modules/.bin/firebase` 直接参照から、固定版 `firebase-tools@15.23.0` の `bunx` 実行へ変更
- CI の test ジョブで Firebase CLI を事前取得し、cold install がテストの 30 秒待機期限に含まれないように変更

## 原因と影響

`firebase-tools` を devDependencies から外した後もテストがローカルバイナリを参照していたため、CI では Emulator が起動しませんでした。`bunx` へ切り替えた初回 run では cold install の native rebuild が 30 秒を超えたため、test ジョブで先に CLI を準備します。build/quality ジョブの依存削減は維持されます。

## 検証

- `bun test` — 137 tests passed
- Firebase CLI warm-up 後のルールテスト — 38 tests passed
- `bun run lint`
- `bun run stylelint`
- `bun run typecheck`
- `bun run format:check`