### PR TITLE
fix: Firebase 設定を遅延評価する

### DIFF
--- a/src/shared/lib/firebase/client.ts
+++ b/src/shared/lib/firebase/client.ts
@@ -1,4 +1,3 @@
-import type { FirebaseOptions } from 'firebase/app';
 import { getApp, getApps, initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
@@ -6,18 +5,17 @@ import { getStorage } from 'firebase/storage';
 
 import { clientEnv } from '@/shared/lib/env';
 
-const firebaseConfig: FirebaseOptions = {
-  apiKey: clientEnv.firebaseApiKey,
-  authDomain: clientEnv.firebaseAuthDomain,
-  projectId: clientEnv.firebaseProjectId,
-  storageBucket: clientEnv.firebaseStorageBucket,
-  appId: clientEnv.firebaseAppId,
-};
-
-const databaseId = clientEnv.firebaseFirestoreDatabaseId;
-
-const getFirebaseApp = () => (getApps().length > 0 ? getApp() : initializeApp(firebaseConfig));
+const getFirebaseApp = () =>
+  getApps().length > 0
+    ? getApp()
+    : initializeApp({
+        apiKey: clientEnv.firebaseApiKey,
+        authDomain: clientEnv.firebaseAuthDomain,
+        projectId: clientEnv.firebaseProjectId,
+        storageBucket: clientEnv.firebaseStorageBucket,
+        appId: clientEnv.firebaseAppId,
+      });
 
 export const getFirebaseAuth = () => getAuth(getFirebaseApp());
-export const getFirebaseFirestore = () => getFirestore(getFirebaseApp(), databaseId);
+export const getFirebaseFirestore = () => getFirestore(getFirebaseApp(), clientEnv.firebaseFirestoreDatabaseId);
 export const getFirebaseStorage = () => getStorage(getFirebaseApp());


### PR DESCRIPTION
## 変更内容

Firebase クライアント設定と Firestore database ID の環境変数読み取りを、モジュールの import 時ではなく Firebase SDK の利用時まで遅延させます。

## 原因

`useFirebaseAuth.test.ts` が認証モジュールを import しただけで `client.ts` の Firebase 設定が評価され、CI にない `NEXT_PUBLIC_FIREBASE_API_KEY` を要求してテスト開始前に失敗していました。

## 影響

Firebase SDK を実際に利用する際の必須環境変数チェックは維持しつつ、Firebase を初期化しないコードやテストは設定値なしで import できます。

## 検証

- `NEXT_PUBLIC_FIREBASE_API_KEY= bun test src/shared/lib/firebase/useFirebaseAuth.test.ts`
- `bun run lint`
- `bun run stylelint`
- `bun run typecheck`
- `bun run format:check`

全テストのローカル実行では 101 件通過後、Firebase Emulator の初回起動が 30 秒を超えてタイムアウトしました。GitHub Actions の事前 CLI 準備環境で最終確認します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Firebase Storageへアクセスする機能を追加しました。

* **改善**
  * Firebaseの認証・データベース接続処理を整理し、動作の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->