### PR TITLE
fix: preserve Firebase auth exports in test mock

### DIFF
--- a/src/features/account/firebase/accountStore.test.tsx
+++ b/src/features/account/firebase/accountStore.test.tsx
@@ -5,6 +5,8 @@ import * as firebaseAuth from 'firebase/auth';
 import * as firestore from 'firebase/firestore';
 import { atom } from 'jotai';
 
+import * as firebaseAuthHook from '@/shared/lib/firebase/useFirebaseAuth';
+
 type Snapshot = {
   exists: () => boolean;
   data: () => Record<string, unknown>;
@@ -50,6 +52,7 @@ mock.module('@/shared/lib/firebase/client', () => ({
 }));
 mock.module('@/shared/lib/firebase/storage/avatars', () => ({ uploadAvatarFromUrlToStorage: vi.fn() }));
 mock.module('@/shared/lib/firebase/useFirebaseAuth', () => ({
+  ...firebaseAuthHook,
   authUserAtom: atom({ uid: 'user_1', displayName: 'User', photoURL: null }),
   authUserLoadingAtom: atom(false),
 }));


### PR DESCRIPTION
## What changed

- Preserve the real `useFirebaseAuth` module exports when mocking auth atoms in `accountStore.test.tsx`.

## Why

Bun keeps `mock.module` replacements in the shared test process. The partial mock removed `isExpectedSignInCancellation`, causing `useFirebaseAuth.test.ts` to fail with a missing named export in CI.

## Impact

Test-only change. Production behavior is unchanged.

## Validation

- `bun test` — 141 passed
- `bun run lint`
- `bun run stylelint`
- `bun run typecheck`
- `bun run format:check`
- production `bun run build` with CI dummy Firebase environment variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * Firebase認証関連のテストモックを拡充し、追加の公開エクスポートも正しく扱えるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->